### PR TITLE
Fix emulation-layer bugs (timing, serial, stream) + regression tests

### DIFF
--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -254,12 +254,11 @@ size_t Stream::readBytesUntil(char terminator, char *buffer, size_t length)
 String Stream::readString(size_t max)
 {
     String str;
-    size_t length = str.length();
-    while (length < max) {
+    while (str.length() < max) {
         int c = timedRead();
         if (c < 0) {
             setReadError();
-            continue;//break;	// timeout
+            break;	// timeout
         }
         if (c == 0) break;
         str += (char)c;
@@ -270,12 +269,11 @@ String Stream::readString(size_t max)
 String Stream::readStringUntil(char terminator, size_t max)
 {
     String str;
-    size_t length = str.length();
-    while (length < max) {
+    while (str.length() < max) {
         int c = timedRead();
         if (c < 0) {
             setReadError();
-            continue; //break;	// timeout
+            break;	// timeout
         }
         if (c == 0 || c == terminator) break;
         str += (char)c;

--- a/src/core_pins.cpp
+++ b/src/core_pins.cpp
@@ -86,13 +86,11 @@ void _restart_Teensyduino_(void) __attribute__((noreturn));
 
 void yield(void);
 
-#ifdef _MSC_VER
-time_t t_start = 0;
-unsigned tv_start_unsigned = 0;
-#else
-extern time_t t_start;
+// Defined in Arduino.cpp. The types must match that definition exactly:
+// declaring t_start as time_t here (8 bytes) while it is defined as unsigned
+// (4 bytes) is undefined behaviour and corrupts millis().
+extern unsigned t_start;
 extern unsigned tv_start_unsigned;
-#endif // _MSC_VER
 
 
 using namespace std::chrono;
@@ -127,7 +125,7 @@ void delayMicroseconds(uint32_t usec)
 }
 
 unsigned long nanos() {
-    unsigned long time_in_nanos = 1000 * (micros() - tv_start_unsigned);
+    unsigned long time_in_nanos = 1000 * micros();
     return time_in_nanos;
 }
 

--- a/src/hardware_serial.cpp
+++ b/src/hardware_serial.cpp
@@ -81,7 +81,7 @@ void HardwareSerial::end() {
 }
 
 int HardwareSerial::available(void) {
-    return !input.empty() || kbhit();
+    return static_cast<int>(input.size()) + kbhit();
 }
 
 void HardwareSerial::begin(unsigned long, uint8_t) {
@@ -89,6 +89,8 @@ void HardwareSerial::begin(unsigned long, uint8_t) {
 }
 
 int HardwareSerial::peek(void) {
+  if (!input.empty())
+    return input.front();
   return std::cin.peek();
 }
 
@@ -155,7 +157,7 @@ size_t HardwareSerial::write(uint8_t a) {
             callback(&c, 1);
         }
     }
-    return 0;
+    return 1;
 }
 size_t HardwareSerial::write(unsigned char const* value, unsigned long count) {
     auto value2 = reinterpret_cast<const char *>(value);
@@ -166,7 +168,7 @@ size_t HardwareSerial::write(unsigned char const* value, unsigned long count) {
             callback(value2, count);
         }
     }
-    return 0;
+    return count;
 }
 
 HardwareSerial Serial;

--- a/test/bugs/CMakeLists.txt
+++ b/test/bugs/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+project(bugs_test C CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+# Unlike the other test apps, this one builds against the LOCAL working copy of
+# the library (../../src) so it verifies the code in this checkout rather than
+# whatever is on GitHub main.
+set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+file(GLOB LIB_SOURCES ${LIB_DIR}/*.cpp)
+if (NOT MSVC)
+    list(REMOVE_ITEM LIB_SOURCES ${LIB_DIR}/ctz_clz.cpp)  # MSVC-only intrinsics
+endif()
+
+add_compile_definitions(__IMXRT1062__ ARDUINO_TEENSY41 ARDUINO=158)
+include_directories(${LIB_DIR})
+
+add_executable(bugs bugs.cpp ${LIB_SOURCES})
+find_package(Threads REQUIRED)
+target_link_libraries(bugs Threads::Threads)

--- a/test/bugs/bugs.cpp
+++ b/test/bugs/bugs.cpp
@@ -1,0 +1,122 @@
+// Regression tests for bugs found in the teensy-x86-stubs emulation layer.
+//
+// Unlike test/blink and test/first (which fetch the library from GitHub via
+// DeclareAndFetch), this test links against the LOCAL src/ so it verifies the
+// current working tree. Each CHECK encodes the *correct* behaviour, so a
+// failing CHECK means the bug is present; once the bug is fixed the test passes.
+//
+// Run with stdin redirected from /dev/null so the console/keyboard paths are
+// deterministic:  ./bugs < /dev/null
+
+#include <Arduino.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static int g_failures = 0;
+static int g_total = 0;
+
+#define CHECK(cond, msg)                                            \
+    do {                                                            \
+        ++g_total;                                                  \
+        if (cond) {                                                 \
+            std::printf("  [PASS] %s\n", msg);                      \
+        } else {                                                    \
+            ++g_failures;                                           \
+            std::printf("  [FAIL] %s\n", msg);                      \
+        }                                                           \
+    } while (0)
+
+// Drain anything left in the simulated-input queue between tests.
+static void drain() {
+    while (Serial.read() != -1) { /* discard */ }
+}
+
+// Bug #1: nanos() subtracts the start baseline a second time (core_pins.cpp).
+// Correct: nanos() ~= micros() * 1000. Buggy: astronomically large (underflow).
+static void test_nanos_baseline() {
+    std::printf("Bug #1  nanos() double-subtracts baseline\n");
+    delay(5);
+    unsigned long us_before = micros();
+    unsigned long ns        = nanos();
+    unsigned long us_after  = micros();
+    // ns should fall within [us_before*1000, us_after*1000] plus a little slack.
+    unsigned long lo = (unsigned long)us_before * 1000UL;
+    unsigned long hi = (unsigned long)us_after  * 1000UL + 5UL * 1000000UL;
+    CHECK(ns >= lo && ns <= hi, "nanos() approximately equals micros()*1000");
+}
+
+// Bug #2: t_start declared `time_t` in core_pins.cpp but defined `unsigned` in
+// Arduino.cpp. This is UB and may pass by luck; included as a sanity guard.
+static void test_millis_sanity() {
+    std::printf("Bug #2  t_start type mismatch (sanity, may pass despite UB)\n");
+    uint32_t m = millis();
+    CHECK(m < 60u * 60u * 1000u, "millis() is a small 'since start' value, not an epoch");
+}
+
+// Bug #3: peek() reads std::cin and ignores the simulated-input queue that
+// read() honours. Every Stream parser relies on peek().
+static void test_peek_uses_queue() {
+    std::printf("Bug #3  peek() ignores simulated-input queue\n");
+    drain();
+    char in[] = {'7', 'x'};
+    Serial.queueSimulatedCharacterInput(in, 2);
+    int p = Serial.peek();
+    int r = Serial.read();
+    CHECK(p == '7', "peek() returns the next queued character");
+    CHECK(r == '7', "read() returns the next queued character");
+    CHECK(p == r,   "peek() agrees with the following read()");
+    drain();
+}
+
+// Bug #4: readStringUntil() captures `length` once and never updates it, so the
+// `max` cap is never enforced. Terminator present => no hang.
+static void test_readstringuntil_max_cap() {
+    std::printf("Bug #4  readStringUntil() ignores its max cap\n");
+    drain();
+    std::string in(200, 'a');       // 200 chars, more than the default max of 120
+    in.push_back('\n');             // terminator so the call returns
+    Serial.queueSimulatedCharacterInput(const_cast<char*>(in.data()),
+                                        (long)in.size());
+    String s = Serial.readStringUntil('\n');   // default max = 120
+    CHECK(s.length() <= 120, "readStringUntil() honours the 120-char max cap");
+    drain();
+}
+
+// Bug #5: write() returns 0 instead of the number of bytes written, violating
+// the Arduino Print contract (Print::print sums these returns).
+static void test_write_return_value() {
+    std::printf("Bug #5  write() returns 0 instead of bytes written\n");
+    std::printf("  (the next line prints 'hello!' to stdout as a side effect)\n  ");
+    size_t n_buf  = Serial.write((const unsigned char*)"hello", 5);
+    size_t n_byte = Serial.write((uint8_t)'!');
+    std::printf("\n");
+    CHECK(n_buf  == 5, "write(buf, 5) returns 5");
+    CHECK(n_byte == 1, "write(byte) returns 1");
+}
+
+// Bug #8: available() collapses the byte count to a 0/1 boolean.
+static void test_available_count() {
+    std::printf("Bug #8  available() returns 0/1 instead of a byte count\n");
+    drain();
+    char in[5] = {'a', 'b', 'c', 'd', 'e'};
+    Serial.queueSimulatedCharacterInput(in, 5);
+    int av = Serial.available();
+    CHECK(av == 5, "available() returns the number of queued bytes (5)");
+    drain();
+}
+
+int main() {
+    initialize_mock_arduino();
+
+    test_nanos_baseline();
+    test_millis_sanity();
+    test_peek_uses_queue();
+    test_readstringuntil_max_cap();
+    test_write_return_value();
+    test_available_count();
+
+    std::printf("\n%d/%d checks passed, %d failed\n",
+                g_total - g_failures, g_total, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes six bugs in the behaviour-bearing parts of the emulation layer (timing, serial I/O, stream parsing) and adds a regression test that reproduces each one. Also adds a `CLAUDE.md` with build/architecture notes.

The new `test/bugs` harness links against the **local** `src/` (unlike `test/blink`/`test/first`, which fetch the library from GitHub `main`), so it verifies the code in this checkout and doubles as a guard against regressions.

## Bugs fixed

| Bug | Fix | File |
|-----|-----|------|
| `nanos()` subtracted the start baseline a second time (underflow → garbage) | return `micros() * 1000` | `core_pins.cpp` |
| `t_start` declared `extern time_t` (8 bytes) but defined `unsigned` (4 bytes) — UB reading `millis()`; MSVC branch also duplicated the definition | declare `extern unsigned t_start` to match the definition | `core_pins.cpp` |
| `peek()` read `std::cin` and ignored the simulated-input queue that `read()` honours, breaking every `Stream` parser on queued input | check the `input` queue first | `hardware_serial.cpp` |
| `write()` returned `0` instead of the number of bytes written, violating the `Print` contract | return `1` / `count` | `hardware_serial.cpp` |
| `available()` collapsed the byte count to a 0/1 boolean | return `input.size() + kbhit()` | `hardware_serial.cpp` |
| `readString()` / `readStringUntil()` captured `length` once (so the `max` cap never applied) and used `continue` on timeout (potential infinite loop) | re-check `str.length()` each iteration and `break` on timeout | `Stream.cpp` |

## Verification

- `test/bugs`: **9/9 checks pass** (was 2/9 before the fixes), exit code 0.
- Root library build (`libteensy_x86_stubs.a`) compiles clean.

```
cd test/bugs && mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Debug .. && cmake --build .
./bugs < /dev/null
```

## Not addressed (out of scope here)

- `IntervalTimer` only supports one active timer (single static `SIGALRM` handler) despite the "up to 4" doc comment.
- `HardwareSerial::printf` uses a VLA + `length+100` buffer, which is non-portable (won't compile under MSVC) and UB if `snprintf` returns < 0.

These are design/portability issues not covered by the deterministic tests; happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAsvzgsaayj2nbZnnQGAav)_