### PR TITLE
Fix README typos and clarify consumer build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![first](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/first.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/first.yml)
 [![root](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/root.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/root.yml)
 
-stub classes implementing basic arduino/teensy functions for compiling and debuging on your x86/x64 architecture
+stub classes implementing basic arduino/teensy functions for compiling and debugging on your x86/x64 architecture (Linux, macOS, Windows/MSVC)
 
 ## eco-system
 [sd](https://github.com/newdigate/teensy-x86-sd-stubs)
@@ -39,10 +39,13 @@ int main(int argc, char **argv){
 ```
 
 ## CMakelists.txt reference
-* using macro from [cmake-declare-and-fetch](https://github.com/newdigate/cmake-declare-and-fetch)
+* the `DeclareAndFetch` macro comes from [cmake-declare-and-fetch](https://github.com/newdigate/cmake-declare-and-fetch) —
+  copy its `cmake_declare_and_fetch.cmake.in` next to your `CMakeLists.txt` (see `test/` in this repo for an example)
   
 ``` cmake
+cmake_minimum_required(VERSION 3.10)
 project(thing C CXX)
+set(CMAKE_CXX_STANDARD 17)
 include(cmake_declare_and_fetch.cmake.in)
 DeclareAndFetch(teensy_x86_stubs https://github.com/newdigate/teensy-x86-stubs.git main src)
 add_executable(thing main.cpp)
@@ -58,15 +61,17 @@ cd cmake-build-debug
 cmake -DCMAKE_BUILD_TYPE=Debug ..
 cmake --build .
 ```
+* this builds only the `teensy_x86_stubs` library. To actually run something, build one of the
+  standalone test apps (e.g. `test/blink` or `test/first`), each of which has its own `CMakeLists.txt`.
 
-## timing emlation
-* to initialize the arduino timing library so that millis() will return the duration in milliseconds since the test app has been runnning
+## timing emulation
+* to initialize the arduino timing library so that millis() will return the duration in milliseconds since the test app has been running
 ``` c++
     initialize_mock_arduino()
 ```
 
 ## credits
-* simial to [maniacbug/ncore](https://github.com/maniacbug/ncore)
+* similar to [maniacbug/ncore](https://github.com/maniacbug/ncore)
 * Don't Run Unit Tests on the Arduino Device or Emulator 
   * [stackoverflow 11437456](https://stackoverflow.com/a/11437456)
   * includes code from [IronSavior/dsm2_tx](https://github.com/IronSavior/dsm2_tx)


### PR DESCRIPTION
## Summary

Documentation-only cleanup of `README.md`.

- **Typos:** debuging → debugging, emlation → emulation, runnning → running, simial → similar.
- **CMake consumer snippet:** note where `cmake_declare_and_fetch.cmake.in` comes from (the [cmake-declare-and-fetch](https://github.com/newdigate/cmake-declare-and-fetch) repo; `test/` here as an example), and add `cmake_minimum_required` + `set(CMAKE_CXX_STANDARD 17)` so the snippet matches the test apps and compiles the C++17 headers. As written before, copying it would fail on the dangling `include(...)`.
- **Build instructions:** clarify the root build only produces the `teensy_x86_stubs` library, and point readers to the standalone `test/*` apps to actually run something.
- **Platforms:** mention Linux/macOS/Windows-MSVC in the intro line.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAsvzgsaayj2nbZnnQGAav)_