### PR TITLE
Add CI workflow that builds and runs the test/bugs harness

### DIFF
--- a/.github/workflows/bugs.yml
+++ b/.github/workflows/bugs.yml
@@ -1,0 +1,34 @@
+name: bugs
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/test/bugs/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{github.workspace}}/test/bugs/build
+      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{github.workspace}}/test/bugs/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Run tests
+      working-directory: ${{github.workspace}}/test/bugs/build
+      shell: bash
+      # The harness exits non-zero if any check fails. stdin is redirected
+      # from /dev/null so the console/keyboard paths are deterministic in CI.
+      run: ./bugs < /dev/null

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![blink](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/blink.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/blink.yml)
 [![first](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/first.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/first.yml)
 [![root](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/root.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/root.yml)
+[![bugs](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/bugs.yml/badge.svg)](https://github.com/newdigate/teensy-x86-stubs/actions/workflows/bugs.yml)
 
 stub classes implementing basic arduino/teensy functions for compiling and debugging on your x86/x64 architecture (Linux, macOS, Windows/MSVC)
 


### PR DESCRIPTION
## Summary

Adds a `bugs` GitHub Actions workflow that builds **and runs** the `test/bugs` regression harness (added in #13), plus a matching README status badge.

On every push it:
1. Configures CMake for `test/bugs`
2. Builds the harness (linked against the local `src/`)
3. Runs `./bugs < /dev/null`

The harness exits non-zero on any failed check, so a regression in the fixed timing/serial/stream behaviour (`nanos`, `peek`, `readStringUntil` max cap, `write` return value, `available` count) will now fail CI. This is the first workflow in the repo that actually *runs* a binary — the existing `root`/`blink`/`first` workflows only build.

`stdin` is redirected from `/dev/null` so the console/keyboard paths are deterministic in CI.

## Verification

Built and ran locally via the workflow's exact steps: **9/9 checks pass**, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAsvzgsaayj2nbZnnQGAav)_